### PR TITLE
Make sure html.vim is included

### DIFF
--- a/after/syntax/jsx.vim
+++ b/after/syntax/jsx.vim
@@ -21,6 +21,7 @@ if exists('b:current_syntax')
   unlet b:current_syntax
 endif
 
+syn include @HTMLSyntax syntax/html.vim
 if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif


### PR DESCRIPTION
The syntax file is dependant on the html syntax being loaded.
It's not always the case, for example, it isn't for me.

This fixes and loads the html definitions for everyone.