### PR TITLE
Highlight tsxCloseTagName

### DIFF
--- a/after/syntax/tsx.vim
+++ b/after/syntax/tsx.vim
@@ -198,6 +198,7 @@ syntax match tsxElseOperator +:+
 highlight def link tsxTagName xmlTagName
 highlight def link tsxTag htmlTag
 highlight def link tsxCloseTag xmlEndTag
+highlight def link tsxCloseTagName xmlTagName
 highlight def link tsxRegionEnd xmlEndTag
 highlight def link tsxEqual htmlTag
 highlight def link tsxString String


### PR DESCRIPTION
Right now tsxCloseTagName doesn't have any highlighting

Lets fix that

Before:
![Screen Shot 2020-04-28 at 8 17 26 pm](https://user-images.githubusercontent.com/3936773/80522719-4e94f380-898d-11ea-8974-d0956b723731.png)
After:
![Screen Shot 2020-04-28 at 8 17 06 pm](https://user-images.githubusercontent.com/3936773/80522727-52c11100-898d-11ea-933b-80359a3d7f07.png)
