### PR TITLE
Not set .jsx file to typescript filetype

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -4,4 +4,4 @@
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 autocmd FileType typescript.tsx setlocal commentstring={/*\ %s\ */}
-autocmd BufNewFile,BufRead *.tsx,*jsx set filetype=typescript.tsx
+autocmd BufNewFile,BufRead *.tsx set filetype=typescript.tsx


### PR DESCRIPTION
Current behavior would confuse tsserver to consider it as typescript file, but it should be not.