### PR TITLE
Add syntax match for tsxComponentName

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Set jsx-tag colors in vimrc, for example:
 " dark red
 hi tsxTagName guifg=#E06C75
 hi tsxComponentName guifg=#E06C75
+hi tsxCloseComponentName guifg=#E06C75
 
 " orange
 hi tsxCloseString guifg=#F99575

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Set jsx-tag colors in vimrc, for example:
 ```
 " dark red
 hi tsxTagName guifg=#E06C75
+hi tsxComponentName guifg=#E06C75
 
 " orange
 hi tsxCloseString guifg=#F99575

--- a/after/syntax/tsx.vim
+++ b/after/syntax/tsx.vim
@@ -150,11 +150,23 @@ syntax match tsxComment /<!--\_.\{-}-->/ display
 syntax match tsxEntity "&[^; \t]*;" contains=tsxEntityPunct
 syntax match tsxEntityPunct contained "[&.;]"
 
+" <MyComponent ...>
+"  ~~~~~~~~~~~
+" NOT
+" <someCamel ...>
+"      ~~~~~
+syntax match tsxComponentName
+      \ +\<[_$]\?[A-Z][-_$A-Za-z0-9]*\>+
+      \ contained
+      \ display
+
+
 " <tag key={this.props.key}>
 "  ~~~
 syntax match tsxTagName
     \ +[<]\@<=[^ /!?<>"']\++
     \ contained
+    \ contains=tsxComponentName
     \ display
 
 " </tag>
@@ -196,6 +208,7 @@ syntax match tsxElseOperator +:+
 
 " highlight def link tsxTagName htmlTagName
 highlight def link tsxTagName xmlTagName
+highlight def link tsxComponentName xmlTagName
 highlight def link tsxTag htmlTag
 highlight def link tsxCloseTag xmlEndTag
 highlight def link tsxCloseTagName xmlTagName

--- a/after/syntax/tsx.vim
+++ b/after/syntax/tsx.vim
@@ -160,6 +160,10 @@ syntax match tsxComponentName
       \ contained
       \ display
 
+syntax match tsxCloseComponentName
+    \ +[</]\?[A-Z][-_$A-Za-z0-9]*\>+
+    \ contained
+    \ display
 
 " <tag key={this.props.key}>
 "  ~~~
@@ -174,6 +178,7 @@ syntax match tsxTagName
 syntax match tsxCloseTagName
     \ +[</]\@<=[^ /!?<>"']\++
     \ containedin=tsxCloseTag
+    \ contains=tsxCloseComponentName
     \ display
 
 " <tag key={this.props.key}>
@@ -209,6 +214,7 @@ syntax match tsxElseOperator +:+
 " highlight def link tsxTagName htmlTagName
 highlight def link tsxTagName xmlTagName
 highlight def link tsxComponentName xmlTagName
+highlight def link tsxCloseComponentName xmlTagName
 highlight def link tsxTag htmlTag
 highlight def link tsxCloseTag xmlEndTag
 highlight def link tsxCloseTagName xmlTagName


### PR DESCRIPTION
Adds new `tsxComponentName` option which will detect react components using component naming conventions.

It's useful to have react components highlighted differently from html elements. I used the syntax matching [already used in vim-jsx-pretty](https://github.com/MaxMEllon/vim-jsx-pretty/blob/master/after/syntax/jsx_pretty.vim#L119) and tested it locally. 

Please let me know if this is something you would consider merging and/or if there are any updates that would make it more useful. 

Thank you so much for your work on this plugin!