### PR TITLE
Fix switch indentation

### DIFF
--- a/after/indent/typescriptreact.vim
+++ b/after/indent/typescriptreact.vim
@@ -37,7 +37,7 @@ function! s:SynEOL(lnum)
 endfunction
 
 function! s:SynAttrJSX(synattr)
-  return a:synattr =~ "^tsx"
+  return a:synattr =~ "^tsx" && a:synattr !=# 'tsxElseOperator'
 endfunction
 
 function! s:SynXMLish(syns)


### PR DESCRIPTION
Before this PR:

```typescript
switch (..) {
  case ..:
  line1...      // <- not this weird indent
    line2...
    break;
}
```

After:

```typescript
switch (..) {
  case ..:
    line1...
    line2...
    break;
}
```
